### PR TITLE
Add support for using serviceaccount annotations

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -51,6 +51,9 @@ type kubeAuthBackend struct {
 	// review. Mocks should only be used in tests.
 	reviewFactory tokenReviewFactory
 
+	// serviceAccountReaderFactory is used to read service account annotations
+	serviceAccountReaderFactory serviceAccountReaderFactory
+
 	// localSATokenReader caches the service account token in memory.
 	// It periodically reloads the token to support token rotation/renewal.
 	// Local token is used when running in a pod with following configuration
@@ -105,6 +108,7 @@ func Backend() *kubeAuthBackend {
 
 	// Set the review factory to default to calling into the kubernetes API.
 	b.reviewFactory = tokenReviewAPIFactory
+	b.serviceAccountReaderFactory = serviceAccountAPIFactory
 
 	return b
 }

--- a/path_config.go
+++ b/path_config.go
@@ -82,6 +82,14 @@ then this plugin will use kubernetes.io/serviceaccount as the default issuer.
 					Name: "Disable use of local CA and service account JWT",
 				},
 			},
+			"enable_custom_metadata_from_annotations": {
+				Type:        framework.TypeBool,
+				Description: "Enable reading and parsing annotations from service account for policy templating",
+				Default:     false,
+				DisplayAttrs: &framework.DisplayAttributes{
+					Name: "Enable reading and parsing service account annotations",
+				},
+			},
 		},
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.UpdateOperation: b.pathConfigWrite,
@@ -110,6 +118,7 @@ func (b *kubeAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reque
 				"issuer":                 config.Issuer,
 				"disable_iss_validation": config.DisableISSValidation,
 				"disable_local_ca_jwt":   config.DisableLocalCAJwt,
+				"enable_custom_metadata_from_annotations": config.EnableCustomMetadataFromAnnotations,
 			},
 		}
 
@@ -130,6 +139,7 @@ func (b *kubeAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Requ
 	issuer := data.Get("issuer").(string)
 	disableIssValidation := data.Get("disable_iss_validation").(bool)
 	tokenReviewer := data.Get("token_reviewer_jwt").(string)
+	enableCustomMetadata := data.Get("enable_custom_metadata_from_annotations").(bool)
 
 	if tokenReviewer != "" {
 		// Validate it's a JWT
@@ -144,14 +154,15 @@ func (b *kubeAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Requ
 	}
 
 	config := &kubeConfig{
-		PublicKeys:           make([]interface{}, len(pemList)),
-		PEMKeys:              pemList,
-		Host:                 host,
-		CACert:               caCert,
-		TokenReviewerJWT:     tokenReviewer,
-		Issuer:               issuer,
-		DisableISSValidation: disableIssValidation,
-		DisableLocalCAJwt:    disableLocalJWT,
+		PublicKeys:                          make([]interface{}, len(pemList)),
+		PEMKeys:                             pemList,
+		Host:                                host,
+		CACert:                              caCert,
+		TokenReviewerJWT:                    tokenReviewer,
+		Issuer:                              issuer,
+		DisableISSValidation:                disableIssValidation,
+		DisableLocalCAJwt:                   disableLocalJWT,
+		EnableCustomMetadataFromAnnotations: enableCustomMetadata,
 	}
 
 	var err error
@@ -195,6 +206,9 @@ type kubeConfig struct {
 	// the local CA cert and service account jwt when running in a Kubernetes
 	// pod
 	DisableLocalCAJwt bool `json:"disable_local_ca_jwt"`
+	// EnableCustomMetadataFromAnnotations is an optional parameter which will cause
+	// us to read the kubernetes ServiceAccount's annotations as metadata of auth alias.
+	EnableCustomMetadataFromAnnotations bool `json:"enable_custom_metadata_from_annotations"`
 }
 
 // PasrsePublicKeyPEM is used to parse RSA and ECDSA public keys from PEMs

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -47,6 +47,7 @@ func TestConfig_Read(t *testing.T) {
 		"issuer":                 "",
 		"disable_iss_validation": false,
 		"disable_local_ca_jwt":   false,
+		"enable_custom_metadata_from_annotations": false,
 	}
 
 	req := &logical.Request{

--- a/path_login.go
+++ b/path_login.go
@@ -92,7 +92,7 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 		return nil, err
 	}
 
-	serviceAccount, err := b.parseAndValidateJWT(jwtStr, role, config)
+	serviceAccount, err := b.parseAndValidateJWT(ctx, jwtStr, role, config)
 	if err != nil {
 		return nil, err
 	}
@@ -113,6 +113,7 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 	if err != nil {
 		return nil, err
 	}
+
 	auth := &logical.Auth{
 		Alias: &logical.Alias{
 			Name: aliasName,
@@ -134,6 +135,21 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 			"role":                        roleName,
 		},
 		DisplayName: fmt.Sprintf("%s-%s", serviceAccount.namespace(), serviceAccount.name()),
+	}
+
+	if serviceAccount.Annotations != nil {
+		for key, value := range serviceAccount.Annotations {
+			// Ensure it's not possible to overwrite service_account_* information
+			if _, exists := auth.Alias.Metadata[key]; exists {
+				continue
+			}
+			if _, exists := auth.Metadata[key]; exists {
+				continue
+			}
+
+			auth.Alias.Metadata[key] = value
+			auth.Metadata[key] = value
+		}
 	}
 
 	role.PopulateTokenAuth(auth)
@@ -198,7 +214,7 @@ func (b *kubeAuthBackend) aliasLookahead(ctx context.Context, req *logical.Reque
 
 	// validation of the JWT against the provided role ensures alias look ahead requests
 	// are authentic.
-	sa, err := b.parseAndValidateJWT(jwtStr, role, config)
+	sa, err := b.parseAndValidateJWT(ctx, jwtStr, role, config)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +234,7 @@ func (b *kubeAuthBackend) aliasLookahead(ctx context.Context, req *logical.Reque
 }
 
 // parseAndValidateJWT is used to parse, validate and lookup the JWT token.
-func (b *kubeAuthBackend) parseAndValidateJWT(jwtStr string, role *roleStorageEntry, config *kubeConfig) (*serviceAccount, error) {
+func (b *kubeAuthBackend) parseAndValidateJWT(ctx context.Context, jwtStr string, role *roleStorageEntry, config *kubeConfig) (*serviceAccount, error) {
 	// Parse into JWT
 	parsedJWT, err := jws.ParseJWT([]byte(jwtStr))
 	if err != nil {
@@ -251,6 +267,15 @@ func (b *kubeAuthBackend) parseAndValidateJWT(jwtStr string, role *roleStorageEn
 
 			return nil
 		},
+	}
+
+	if config.EnableCustomMetadataFromAnnotations {
+		annotations, err := b.serviceAccountReaderFactory(config).ReadAnnotations(ctx, sa.Name, sa.Namespace)
+		if err != nil {
+			return nil, err
+		}
+
+		sa.Annotations = annotations
 	}
 
 	// perform ISS Claim validation if configured
@@ -357,6 +382,9 @@ type serviceAccount struct {
 	Kubernetes *projectedServiceToken `mapstructure:"kubernetes.io"`
 	Expiration int64                  `mapstructure:"exp"`
 	IssuedAt   int64                  `mapstructure:"iat"`
+
+	// todo: explain
+	Annotations map[string]string
 }
 
 // uid returns the UID for the service account, preferring the projected service

--- a/path_login.go
+++ b/path_login.go
@@ -383,7 +383,9 @@ type serviceAccount struct {
 	Expiration int64                  `mapstructure:"exp"`
 	IssuedAt   int64                  `mapstructure:"iat"`
 
-	// todo: explain
+	// Kubernetes annotations for the service account with the `allowedAnnotationPrefix`,
+	// which will be loaded here if `config.EnableCustomMetadataFromAnnotations` is 
+	// enabled.
 	Annotations map[string]string
 }
 

--- a/service_account_lookup.go
+++ b/service_account_lookup.go
@@ -1,0 +1,120 @@
+package kubeauth
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	cleanhttp "github.com/hashicorp/go-cleanhttp"
+	corev1 "k8s.io/api/core/v1"
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const allowedAnnotationPrefix = "vault.hashicorp.com/auth-metadata/"
+
+type serviceAccountReader interface {
+	ReadAnnotations(ctx context.Context, name, namespace string) (map[string]string, error)
+}
+
+type serviceAccountReaderFactory func(*kubeConfig) serviceAccountReader
+
+func serviceAccountAPIFactory(config *kubeConfig) serviceAccountReader {
+	s := &serviceAccountAPI{
+		client: cleanhttp.DefaultPooledClient(),
+		config: config,
+	}
+
+	// If we have a CA cert build the TLSConfig
+	if len(config.CACert) > 0 {
+		certPool := x509.NewCertPool()
+		certPool.AppendCertsFromPEM([]byte(config.CACert))
+
+		tlsConfig := &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			RootCAs:    certPool,
+		}
+
+		s.client.Transport.(*http.Transport).TLSClientConfig = tlsConfig
+	}
+
+	return s
+}
+
+type serviceAccountAPI struct {
+	client *http.Client
+	config *kubeConfig
+}
+
+func (s *serviceAccountAPI) ReadAnnotations(ctx context.Context, name, namespace string) (map[string]string, error) {
+	uri := fmt.Sprintf("/api/v1/namespaces/%s/serviceaccounts/%s", namespace, name)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	bearer := fmt.Sprintf("Bearer %s", strings.TrimSpace(s.config.TokenReviewerJWT))
+
+	req.Header.Set("Authorization", bearer)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	rsp, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	svcAccount, err := parseServiceAccountResponse(rsp)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter for annotations that have a prefix and are destined for this plugin
+	filtered := map[string]string{}
+	for key, value := range svcAccount.Annotations {
+		if strings.HasPrefix(key, allowedAnnotationPrefix) {
+			// Normalise the annotations to match the current snake_case pattern.
+			// Ex: vault.hashicorp.com/auth-metadata/service-role: authorization
+			// Will become: service_role: authorization
+			key := strings.ReplaceAll(strings.TrimPrefix(key, allowedAnnotationPrefix), "-", "_")
+			filtered[key] = value
+		}
+	}
+
+	return filtered, nil
+}
+
+// parseResponse takes the API response and either returns the appropriate error
+// or the TokenReview Object.
+func parseServiceAccountResponse(rsp *http.Response) (*corev1.ServiceAccount, error) {
+	body, err := ioutil.ReadAll(rsp.Body)
+	if err != nil {
+		return nil, err
+	}
+	defer rsp.Body.Close()
+
+	if rsp.StatusCode < http.StatusOK || rsp.StatusCode > http.StatusPartialContent {
+		return nil, kubeerrors.NewGenericServerResponse(rsp.StatusCode, "POST", schema.GroupResource{}, "", strings.TrimSpace(string(body)), 0, true)
+	}
+
+	errStatus := &metav1.Status{}
+	err = json.Unmarshal(body, errStatus)
+	if err == nil && errStatus.Status != metav1.StatusSuccess {
+		return nil, kubeerrors.FromObject(runtime.Object(errStatus))
+	}
+
+	svcAccount := &corev1.ServiceAccount{}
+	err = json.Unmarshal(body, svcAccount)
+	if err != nil {
+		return nil, err
+	}
+
+	return svcAccount, nil
+}

--- a/service_account_lookup.go
+++ b/service_account_lookup.go
@@ -13,12 +13,10 @@ import (
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	corev1 "k8s.io/api/core/v1"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-const allowedAnnotationPrefix = "vault.hashicorp.com/auth-metadata/"
+const allowedAnnotationPrefix = "auth-metadata.vault.hashicorp.com/"
 
 type serviceAccountReader interface {
 	ReadAnnotations(ctx context.Context, name, namespace string) (map[string]string, error)
@@ -54,8 +52,8 @@ type serviceAccountAPI struct {
 }
 
 func (s *serviceAccountAPI) ReadAnnotations(ctx context.Context, name, namespace string) (map[string]string, error) {
-	uri := fmt.Sprintf("/api/v1/namespaces/%s/serviceaccounts/%s", namespace, name)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+	url := fmt.Sprintf("%s/api/v1/namespaces/%s/serviceaccounts/%s", strings.TrimSuffix(s.config.Host, "/"), namespace, name)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -68,12 +66,12 @@ func (s *serviceAccountAPI) ReadAnnotations(ctx context.Context, name, namespace
 
 	rsp, err := s.client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to talk to kubernetes API: %v", err)
 	}
 
 	svcAccount, err := parseServiceAccountResponse(rsp)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse serviceaccount response: %v", err)
 	}
 
 	// Filter for annotations that have a prefix and are destined for this plugin
@@ -81,7 +79,7 @@ func (s *serviceAccountAPI) ReadAnnotations(ctx context.Context, name, namespace
 	for key, value := range svcAccount.Annotations {
 		if strings.HasPrefix(key, allowedAnnotationPrefix) {
 			// Normalise the annotations to match the current snake_case pattern.
-			// Ex: vault.hashicorp.com/auth-metadata/service-role: authorization
+			// Ex: auth-metadata.vault.hashicorp.com/service-role: authorization
 			// Will become: service_role: authorization
 			key := strings.ReplaceAll(strings.TrimPrefix(key, allowedAnnotationPrefix), "-", "_")
 			filtered[key] = value
@@ -96,7 +94,7 @@ func (s *serviceAccountAPI) ReadAnnotations(ctx context.Context, name, namespace
 func parseServiceAccountResponse(rsp *http.Response) (*corev1.ServiceAccount, error) {
 	body, err := ioutil.ReadAll(rsp.Body)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read out body: %v", err)
 	}
 	defer rsp.Body.Close()
 
@@ -104,16 +102,10 @@ func parseServiceAccountResponse(rsp *http.Response) (*corev1.ServiceAccount, er
 		return nil, kubeerrors.NewGenericServerResponse(rsp.StatusCode, "POST", schema.GroupResource{}, "", strings.TrimSpace(string(body)), 0, true)
 	}
 
-	errStatus := &metav1.Status{}
-	err = json.Unmarshal(body, errStatus)
-	if err == nil && errStatus.Status != metav1.StatusSuccess {
-		return nil, kubeerrors.FromObject(runtime.Object(errStatus))
-	}
-
 	svcAccount := &corev1.ServiceAccount{}
 	err = json.Unmarshal(body, svcAccount)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal into corev1.ServiceAccount: %v", err)
 	}
 
 	return svcAccount, nil


### PR DESCRIPTION
Addresses [hashicorp#85](https://github.com/hashicorp/vault-plugin-auth-kubernetes/issues/85)

We took Mark's proposed design and added support for defining annotations on service accounts that can later on be used in policy templating.

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: example-account
  namespace: default
  annotations:
    vault.hashicorp.com/auth-metadata/service-role: example-value
```

Should allow us to use in policies as so
```
{{identity.entity.aliases.${vault_auth_backend.kubernetes.accessor}.metadata.service_role}}
```

**Who the change affects or is for (stakeholders)?**
The change is behind a config flag called `enable_custom_metadata_from_annotations` so it should not affect any of the existing integrations.
In order to enable the flag users will have to update the clusterrole and allow Vault to read service accounts. If this change is accepted we'll open PRs to update various docs, terraform providers, etc.
This will also introduce another roundtrip to the Kubernetes API, however we are using a pooled tcp client so hopefully not too many new open connections.

**Why is the change needed?**
At Monzo we want to use fully qualified service names for certificates issued under Vault's PKI, ie `service.profile` which we can attach as annotations to service accounts. At the same time we want the policies to be very strict so `service.profile` is not allowed to obtain certificates for `service.id`.

# Design of Change
We've largely adhered to the current code style present in the repo. 
All changes are behind a config flag `enable_custom_metadata_from_annotations` so existing integrations shouldn't be affected.

# Related Issues/Pull Requests
TBD

# Contributor Checklist
TBD
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x] Backwards compatible
