### PR TITLE
Use `namespace()` and `name()` wrapper functions

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -289,7 +289,7 @@ func (b *kubeAuthBackend) parseAndValidateJWT(ctx context.Context, jwtStr string
 	}
 
 	if config.EnableCustomMetadataFromAnnotations {
-		annotations, err := b.serviceAccountReaderFactory(config).ReadAnnotations(ctx, sa.Name, sa.Namespace)
+		annotations, err := b.serviceAccountReaderFactory(config).ReadAnnotations(ctx, sa.name(), sa.namespace())
 		if err != nil {
 			return nil, fmt.Errorf("failed to read serviceaccount annotations: %v", err)
 		}


### PR DESCRIPTION
With K8S 1.21 bound tokens are now the default which have the name and namespaces in a different location. The wrapper functions take care of picking out the correct function automatically.

# Overview
A high level description of the contribution, including:
Who the change affects or is for (stakeholders)?
What is the change? 
Why is the change needed?
How does this change affect the user experience (if at all)?

# Design of Change
How was this change implemented?

# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
